### PR TITLE
Feature/35: JS зависимости прямо в Jar'ке, чтобы веб-приложение работало даже без Интернета

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>2.8.4</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>angularjs</artifactId>
+      <version>1.5.8</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -2,8 +2,8 @@
 <html ng-app="trackerWebApp">
   <head>
     <base href="/">
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-route.js"></script>
+    <script src="webjars/angularjs/1.5.8/angular.min.js"></script>
+    <script src="webjars/angularjs/1.5.8/angular-route.js"></script>
     <script src="trackerWebApp.module.js"></script>
     <script src="trackerWebApp.routes.js"></script>
     <script src="/controllers/allIssuesController.js"></script>


### PR DESCRIPTION
Добавил зависимость с angularjs 1.5.8 в pom.xml. Заменил содержимое тэга, который загружает скрипты на страницу, чтобы скрипты тянулись не из интернета, а непосредственно из jar. Тестировал на нескольких браузерах, предварительно почистив кэш и историю.